### PR TITLE
Fix: default-values are set by "action.yml", and inputs are always strings

### DIFF
--- a/checkout/action.yml
+++ b/checkout/action.yml
@@ -7,7 +7,7 @@ inputs:
     default: false
   with-submodules:
     description: 'should submodules be checked out'
-    default: true
+    default: false
 runs:
   using: 'node12'
   main: 'dist/index.js'

--- a/checkout/dist/index.js
+++ b/checkout/dist/index.js
@@ -354,12 +354,12 @@ function getOutputFromExec(command, args) {
 }
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
-        const withTags = core.getInput('with-tags');
-        const withSubmodules = core.getInput('with-submodules');
-        if (withTags === 'true') {
+        const withTags = (core.getInput('with-tags') || 'false').toUpperCase() === 'TRUE';
+        const withSubmodules = (core.getInput('with-submodules') || 'false').toUpperCase() === 'TRUE';
+        if (withTags) {
             yield exec.exec('git fetch --depth=1 origin +refs/tags/*:refs/tags/*');
         }
-        if (withSubmodules === 'true') {
+        if (withSubmodules) {
             const authHeader = yield getOutputFromExec('git config --local --get http.https://github.com/.extraheader');
             yield exec.exec('git submodule sync --recursive');
             yield exec.exec(`git -c "http.extraheader=${authHeader}" -c protocol.version=2 submodule update --init --force --recursive --depth=1`);

--- a/checkout/dist/index.js
+++ b/checkout/dist/index.js
@@ -354,12 +354,12 @@ function getOutputFromExec(command, args) {
 }
 function run() {
     return __awaiter(this, void 0, void 0, function* () {
-        const withTags = core.getInput('with-tags') || false;
-        const withSubmodules = core.getInput('with-submodules') || true;
-        if (withTags) {
+        const withTags = core.getInput('with-tags');
+        const withSubmodules = core.getInput('with-submodules');
+        if (withTags === 'true') {
             yield exec.exec('git fetch --depth=1 origin +refs/tags/*:refs/tags/*');
         }
-        if (withSubmodules) {
+        if (withSubmodules === 'true') {
             const authHeader = yield getOutputFromExec('git config --local --get http.https://github.com/.extraheader');
             yield exec.exec('git submodule sync --recursive');
             yield exec.exec(`git -c "http.extraheader=${authHeader}" -c protocol.version=2 submodule update --init --force --recursive --depth=1`);

--- a/checkout/src/main.ts
+++ b/checkout/src/main.ts
@@ -19,14 +19,14 @@ async function getOutputFromExec(command: string, args?: string[]): Promise<stri
 }
 
 async function run(): Promise<void> {
-  const withTags = core.getInput('with-tags') || false
-  const withSubmodules = core.getInput('with-submodules') || true
+  const withTags = core.getInput('with-tags')
+  const withSubmodules = core.getInput('with-submodules')
 
-  if (withTags) {
+  if (withTags === 'true') {
     await exec.exec('git fetch --depth=1 origin +refs/tags/*:refs/tags/*')
   }
 
-  if (withSubmodules) {
+  if (withSubmodules === 'true') {
     const authHeader = await getOutputFromExec('git config --local --get http.https://github.com/.extraheader')
 
     await exec.exec('git submodule sync --recursive')

--- a/checkout/src/main.ts
+++ b/checkout/src/main.ts
@@ -19,14 +19,14 @@ async function getOutputFromExec(command: string, args?: string[]): Promise<stri
 }
 
 async function run(): Promise<void> {
-  const withTags = core.getInput('with-tags')
-  const withSubmodules = core.getInput('with-submodules')
+  const withTags = (core.getInput('with-tags') || 'false').toUpperCase() === 'TRUE'
+  const withSubmodules = (core.getInput('with-submodules') || 'false').toUpperCase() === 'TRUE'
 
-  if (withTags === 'true') {
+  if (withTags) {
     await exec.exec('git fetch --depth=1 origin +refs/tags/*:refs/tags/*')
   }
 
-  if (withSubmodules === 'true') {
+  if (withSubmodules) {
     const authHeader = await getOutputFromExec('git config --local --get http.https://github.com/.extraheader')
 
     await exec.exec('git submodule sync --recursive')


### PR DESCRIPTION
Before this commit, it always checked out tags and submodules,
while the request might have been to not do that.