### PR TITLE
Several fixes for repository_dispatch

### DIFF
--- a/checkout-dispatch/dist/index.js
+++ b/checkout-dispatch/dist/index.js
@@ -4705,7 +4705,7 @@ function run() {
         if (github.context.eventName !== 'repository_dispatch') {
             return;
         }
-        if (github.context.action !== 'publish_latest_tag') {
+        if (github.context.payload.action !== 'publish_latest_tag') {
             return;
         }
         const revList = yield getOutputFromExec('git rev-list --tags --max-count=1');

--- a/checkout-dispatch/dist/index.js
+++ b/checkout-dispatch/dist/index.js
@@ -4708,8 +4708,12 @@ function run() {
         if (github.context.payload.action !== 'publish_latest_tag') {
             return;
         }
+        // Make sure we fetch all the tags; otherwise we cannot detect the latest
+        yield exec.exec('git fetch --depth=1 origin +refs/tags/*:refs/tags/*');
+        // Find the latest tag
         const revList = yield getOutputFromExec('git rev-list --tags --max-count=1');
         const describe = yield getOutputFromExec(`git describe ${revList} --tags`);
+        // Switch the code to the latest tag
         const ref = `refs/tags/${describe}`;
         yield exec.exec(`git checkout ${ref}`);
         core.info(`Switched branch to ${ref}`);

--- a/checkout-dispatch/src/main.ts
+++ b/checkout-dispatch/src/main.ts
@@ -23,7 +23,7 @@ async function run(): Promise<void> {
   if (github.context.eventName !== 'repository_dispatch') {
     return
   }
-  if (github.context.action !== 'publish_latest_tag') {
+  if (github.context.payload.action !== 'publish_latest_tag') {
     return
   }
 

--- a/checkout-dispatch/src/main.ts
+++ b/checkout-dispatch/src/main.ts
@@ -27,9 +27,14 @@ async function run(): Promise<void> {
     return
   }
 
+  // Make sure we fetch all the tags; otherwise we cannot detect the latest
+  await exec.exec('git fetch --depth=1 origin +refs/tags/*:refs/tags/*')
+
+  // Find the latest tag
   const revList = await getOutputFromExec('git rev-list --tags --max-count=1')
   const describe = await getOutputFromExec(`git describe ${revList} --tags`)
 
+  // Switch the code to the latest tag
   const ref = `refs/tags/${describe}`
   await exec.exec(`git checkout ${ref}`)
   core.info(`Switched branch to ${ref}`)

--- a/docker-vars/dist/index.js
+++ b/docker-vars/dist/index.js
@@ -4722,7 +4722,7 @@ function run() {
         // is all we got.
         let isStaging;
         if (github.context.eventName === 'repository_dispatch') {
-            if (github.context.action === 'publish_master') {
+            if (github.context.payload.action === 'publish_master') {
                 isStaging = true;
             }
             else {

--- a/docker-vars/src/main.ts
+++ b/docker-vars/src/main.ts
@@ -46,7 +46,7 @@ async function run(): Promise<void> {
   // is all we got.
   let isStaging
   if (github.context.eventName === 'repository_dispatch') {
-    if (github.context.action === 'publish_master') {
+    if (github.context.payload.action === 'publish_master') {
       isStaging = true
     } else {
       isStaging = false


### PR DESCRIPTION
Currently it was always pushing "master" to "production", which is double wrong.

With this change, it pushes "master" to "staging", and "latest_tag" to "production" again.

This time it is tested :)