### PR TITLE
Fix: push all tags on docker-publish step

### DIFF
--- a/docker-publish/dist/index.js
+++ b/docker-publish/dist/index.js
@@ -390,7 +390,7 @@ function run() {
         const registry = core.getInput('registry') || 'docker.io';
         yield exec.exec(`docker login ${registry} --username ${registryUsername} --password ${registryPassword}`);
         // This pushes all tags of this docker image at once
-        yield exec.exec(`docker push ${registry}/${name}`);
+        yield exec.exec(`docker push --all-tags ${registry}/${name}`);
         const rawDockerTag = yield getOutputFromExec('docker', [
             'inspect',
             '--format={{index .RepoDigests 0}}',

--- a/docker-publish/src/main.ts
+++ b/docker-publish/src/main.ts
@@ -32,7 +32,7 @@ async function run(): Promise<void> {
 
   await exec.exec(`docker login ${registry} --username ${registryUsername} --password ${registryPassword}`)
   // This pushes all tags of this docker image at once
-  await exec.exec(`docker push ${registry}/${name}`)
+  await exec.exec(`docker push --all-tags ${registry}/${name}`)
 
   const rawDockerTag = await getOutputFromExec('docker', [
     'inspect',


### PR DESCRIPTION
GitHub updated their runners, and now the normally implied
"--all-tags" is disabled by default. This broke most of our flows.