### PR TITLE
Fix: [checkout-pull-request] PR commit limit kicked in one round too early

### DIFF
--- a/checkout-pull-request/action.yml
+++ b/checkout-pull-request/action.yml
@@ -13,7 +13,7 @@ runs:
         git -c protocol.version=2 fetch --no-tags --prune --progress --no-recurse-submodules --deepen=${DEPTH} origin HEAD
         DEPTH=$(expr ${DEPTH} \* 4)
 
-        if [ "${DEPTH}" = "256" ]; then
+        if [ "${DEPTH}" -gt "256" ]; then
           echo "No common parent found for this merge commit (max-depth of 256 reached)"
           exit 1
         fi


### PR DESCRIPTION
This made the commit limit effectively 64 instead of the aimed 256.