### PR TITLE
Add: [docker-build] support building for other platforms besides linux/amd64

### DIFF
--- a/docker-build/README.md
+++ b/docker-build/README.md
@@ -22,6 +22,9 @@ Builds the Dockerfile in the root directory to an image.
     # (required) date of the Docker image (given to the Dockerfile as build-argument)
     date: ${{ steps.vars.outputs.date }}
 
+    # (optional) platform to build the Docker image for
+    platform: linux/amd64,linux/arm64
+
     # (optional) Docker registry to use for images
     registry: 'ghcr.io'
 ```

--- a/docker-build/action.yml
+++ b/docker-build/action.yml
@@ -20,6 +20,9 @@ inputs:
   date:
     description: 'Date of the Docker image'
     required: true
+  platform:
+    description: 'Platform to build the Docker image for (e.g.: linux/amd64,linux/arm64)'
+    default: linux/amd64
 
 runs:
   using: 'composite'
@@ -28,7 +31,7 @@ runs:
     run: |
       REPO=${{ inputs.registry }}/${{ inputs.name }}
 
-      docker build -t ${REPO}:${{ inputs.tag }} --build-arg BUILD_DATE=${{ inputs.date }} --build-arg BUILD_VERSION=${{ inputs.version }} .
+      docker buildx build --platform ${{ inputs.platform }} -t ${REPO}:${{ inputs.tag }} --build-arg BUILD_DATE=${{ inputs.date }} --build-arg BUILD_VERSION=${{ inputs.version }} .
 
       IFS=' '
       for alias in ${{ inputs.tags }}; do


### PR DESCRIPTION
Use the action "docker/setup-qemu-action" first to install other
platforms before using ones like linux/arm64, as they are not
activated by default on GitHub Actions.