### PR TITLE
Fix: [publish-image] forgot to readd a statement removed for debugging

### DIFF
--- a/.github/workflows/publish-image.yml
+++ b/.github/workflows/publish-image.yml
@@ -34,7 +34,7 @@ jobs:
       with:
         images: ghcr.io/${{ github.repository }}
         tags: |
-          type=raw,value=dev
+          type=raw,value=dev,enable={{is_default_branch}}
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}


### PR DESCRIPTION
Otherwise every image is a "dev" image too, instead of only
the staging images.