### PR TITLE
Feature: [release] automatically tag the major version on release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  release:
+    types:
+    - published
+
+jobs:
+  major_tag:
+    name: Force major tag
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Update major tag
+      run: |
+        # This turns 'v1.2.3' into 'v1'
+        MAJOR_VERSION=$(echo "${{ github.event.release.tag_name }}" | cut -d\. -f1)
+        git tag -f ${MAJOR_VERSION}
+        git push -f origin ${MAJOR_VERSION}


### PR DESCRIPTION
Normally this was a manual job, that after releasing vN.M.Z,
checkout, tag vN, force push.

This small workflow takes care of this now.