### PR TITLE
Fix: use a new entry-path to deploy services on nomad

### DIFF
--- a/.github/workflows/rw-entry-preview-docker-nomad.yml
+++ b/.github/workflows/rw-entry-preview-docker-nomad.yml
@@ -20,11 +20,8 @@ on:
         required: true
         type: string
     secrets:
-      NOMAD_CF_ACCESS_CLIENT_ID:
-        description: Cloudflare Access Client ID for nomad.openttd.org access
-        required: true
-      NOMAD_CF_ACCESS_CLIENT_SECRET:
-        description: Cloudflare Access Client Secret for nomad.openttd.org access
+      NOMAD_SERVICE_PREVIEW_KEY:
+        description: Secret key to deploy the preview service
         required: true
 
 concurrency:
@@ -49,7 +46,8 @@ jobs:
 
     name: Deploy
     uses: ./.github/workflows/rw-nomad-deploy.yml
-    secrets: inherit
+    secrets:
+      NOMAD_SERVICE_KEY: ${{ secrets.NOMAD_SERVICE_PREVIEW_KEY }}
     with:
       environment: Preview
       service: ${{ inputs.service}}

--- a/.github/workflows/rw-entry-release-docker-nomad.yml
+++ b/.github/workflows/rw-entry-release-docker-nomad.yml
@@ -20,11 +20,8 @@ on:
         required: true
         type: string
     secrets:
-      NOMAD_CF_ACCESS_CLIENT_ID:
-        description: Cloudflare Access Client ID for nomad.openttd.org access
-        required: true
-      NOMAD_CF_ACCESS_CLIENT_SECRET:
-        description: Cloudflare Access Client Secret for nomad.openttd.org access
+      NOMAD_SERVICE_PROD_KEY:
+        description: Secret key to deploy the production service
         required: true
 
 concurrency:
@@ -45,7 +42,8 @@ jobs:
 
     name: Deploy
     uses: ./.github/workflows/rw-nomad-deploy.yml
-    secrets: inherit
+    secrets:
+      NOMAD_SERVICE_KEY: ${{ secrets.NOMAD_SERVICE_PROD_KEY }}
     with:
       environment: Production
       service: ${{ inputs.service }}

--- a/.github/workflows/rw-nomad-deploy.yml
+++ b/.github/workflows/rw-nomad-deploy.yml
@@ -22,11 +22,8 @@ on:
         required: true
         type: string
     secrets:
-      NOMAD_CF_ACCESS_CLIENT_ID:
-        description: Cloudflare Access Client ID for nomad.openttd.org access
-        required: true
-      NOMAD_CF_ACCESS_CLIENT_SECRET:
-        description: Cloudflare Access Client Secret for nomad.openttd.org access
+      NOMAD_SERVICE_KEY:
+        description: Secret key to deploy services
         required: true
 
 concurrency:
@@ -45,8 +42,6 @@ jobs:
     - name: Deploy
       run: |
         curl --fail -L -s -N -X POST \
-          -H "CF-Access-Client-Id: ${{ secrets.NOMAD_CF_ACCESS_CLIENT_ID }}" \
-          -H "CF-Access-Client-Secret: ${{ secrets.NOMAD_CF_ACCESS_CLIENT_SECRET }}" \
           -H "Content-Type: application/json" \
-          -d '{"Meta":{"version":"${{ inputs.version }}"}}' \
-          https://nomad.openttd.org/v1/job/${{ inputs.service }}-deploy/dispatch
+          -d '{"version":"${{ inputs.version }}"}' \
+          https://nomad-service.openttd.org/deploy/${{ inputs.service }}/${{ secrets.NOMAD_SERVICE_KEY }}


### PR DESCRIPTION
This shows much better in GitHub Actions how the deployment is doing, and if there was any problem: where.

It also only stops when the deployment was actually done (instead of when it was being queued).