### PR TITLE
Fix: cancel releases in progress when a new one comes in

### DIFF
--- a/.github/workflows/rw-entry-release-docker-nomad.yml
+++ b/.github/workflows/rw-entry-release-docker-nomad.yml
@@ -26,7 +26,7 @@ on:
 
 concurrency:
   group: release
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   release:


### PR DESCRIPTION
There is actually no need to wait for a release to finish before starting the new one. Worst case, the deployment was busy, but Nomad can handle it just fine if two deployments arrive one after the other.

But more likely it cancels the building of the Dockers, which is totally fine. There, worst case, we pushed some dangling images to the container registry.