### PR TITLE
Feature: reusing workflows for basesets and uploading to CDN

### DIFF
--- a/.github/workflows/rw-annotation-check.yml
+++ b/.github/workflows/rw-annotation-check.yml
@@ -16,4 +16,4 @@ jobs:
 
     steps:
     - name: Check annotations
-      uses: OpenTTD/actions/annotation-check@v3
+      uses: OpenTTD/actions/annotation-check@v4

--- a/.github/workflows/rw-baseset-build.yml
+++ b/.github/workflows/rw-baseset-build.yml
@@ -1,0 +1,123 @@
+name: Baseset Build
+
+# Build an OpenTTD baseset repository.
+
+on:
+  workflow_call:
+    inputs:
+      apt-packages:
+        description: A list of apt packages to install.
+        default: ""
+        required: false
+        type: string
+      name:
+        description: The name of the project.
+        required: true
+        type: string
+      pip-packages:
+        description: A list of pip packages to install.
+        default: ""
+        required: false
+        type: string
+      problem-matcher:
+        description: A problem matcher to use.
+        default: ""
+        required: false
+        type: string
+      publish:
+        description: Whether to publish the bundles.
+        default: false
+        required: false
+        type: boolean
+      release-date:
+        description: The release date of the project.
+        required: true
+        type: string
+      version:
+        description: The version of the project.
+        required: true
+        type: string
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    name: Build
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+
+    - name: Install apt dependencies
+      if: ${{ inputs.apt-packages != '' }}
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install -y ${{ inputs.apt-packages }} --no-install-recommends
+
+    - name: Set up Python 3.8
+      if: ${{ inputs.pip-packages != '' }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.8
+
+    - name: Install pip dependencies
+      if: ${{ inputs.pip-packages != '' }}
+      shell: bash
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install ${{ inputs.pip-packages }}
+
+    - name: Install problem matcher
+      if: ${{ inputs.problem-matcher != '' }}
+      shell: bash
+      run: |
+        echo "::add-matcher::${{ inputs.problem-matcher }}"
+
+    - name: Build
+      shell: bash
+      run: |
+        make maintainer-clean
+        make bundle_zip bundle_xsrc
+
+    - name: Move bundles
+      if: ${{ inputs.publish }}
+      shell: bash
+      run: |
+        mkdir bundles
+
+        mv ${{ inputs.name }}-${{ inputs.version }}-source.tar.xz bundles/
+        mv ${{ inputs.name }}-${{ inputs.version }}-all.zip bundles/
+
+    - name: Create checksums
+      if: ${{ inputs.publish }}
+      shell: bash
+      run: |
+        cd bundles
+
+        for i in $(ls); do
+          openssl dgst -r -md5 -hex $i > $i.md5sum
+          openssl dgst -r -sha1 -hex $i > $i.sha1sum
+          openssl dgst -r -sha256 -hex $i > $i.sha256sum
+        done
+
+    - name: Prepare bundles folder
+      if: ${{ inputs.publish }}
+      shell: bash
+      run: |
+        cd bundles
+
+        echo "${{ inputs.release-date }}" > released.txt
+        cp ../README.md .
+        cp ../changelog.txt .
+
+        # Show the content of the bundles folder, to make problems debugging easier
+        ls -l
+
+    - name: Upload bundles
+      if: ${{ inputs.publish }}
+      uses: actions/upload-artifact@v3
+      with:
+        name: bundles
+        path: bundles/*
+        if-no-files-found: error
+        retention-days: 1

--- a/.github/workflows/rw-baseset-metadata.yml
+++ b/.github/workflows/rw-baseset-metadata.yml
@@ -1,0 +1,83 @@
+name: Baseset Metadata
+
+# Detects metadata for an OpenTTD baseset repository.
+
+on:
+  workflow_call:
+    inputs:
+      name:
+        description: The name of the project.
+        required: true
+        type: string
+    outputs:
+      folder:
+        description: The folder to publish to.
+        value: ${{ jobs.metadata.outputs.folder }}
+      release-date:
+        description: The release date to publish.
+        value: ${{ jobs.metadata.outputs.release-date }}
+      skip:
+        description: Whether to skip the workflow.
+        value: ${{ jobs.metadata.outputs.skip }}
+      version:
+        description: The version to publish.
+        value: ${{ jobs.metadata.outputs.version }}
+
+jobs:
+  metadata:
+    runs-on: ubuntu-latest
+    name: Metadata
+
+    outputs:
+      folder: ${{ steps.metadata.outputs.folder }}
+      release-date: ${{ steps.metadata.outputs.release-date }}
+      skip: ${{ steps.metadata.outputs.skip }}
+      version: ${{ steps.metadata.outputs.version }}
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Metadata
+      id: metadata
+      shell: bash
+      run: |
+        FULL_VERSION=$(./findversion.sh)
+        RELEASE_DATE=$(TZ='UTC' date +"%Y-%m-%d %H:%M UTC")
+        VERSION=$(echo "${FULL_VERSION}" | cut -f 1 -d$'\t')
+        IS_TAG=$(echo "${FULL_VERSION}" | cut -f 5 -d$'\t')
+
+        # If we run on "schedule" / "workflow-dispatch", we are producting a nightly.
+        # Otherwise it is a release.
+        if [ "${{ github.event_name }}" = "schedule" ] || [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+          FOLDER="${{ inputs.name }}-nightlies"
+
+          # Download the latest version we published; if we are different, it
+          # is safe to assume we are newer.
+          LATEST_VERSION=$(curl --fail -s https://cdn.openttd.org/${FOLDER}/latest.yaml | grep version | cut -d: -f2 | cut -b 2-)
+
+          if [ "${IS_TAG}" = "1" ]; then
+            echo "Run on schedule; going to skip this run, last change was released"
+            SKIP="true"
+          elif [ "${LATEST_VERSION}" = "${VERSION}" ]; then
+            echo "Run on schedule; going to skip this run, as we already build this version"
+            SKIP="true"
+          else
+            SKIP="false"
+          fi
+        else
+          FOLDER="${{ inputs.name }}-releases"
+          SKIP="false"
+        fi
+
+        echo "folder=${FOLDER}" >> $GITHUB_OUTPUT
+        echo "release-date=${RELEASE_DATE}" >> $GITHUB_OUTPUT
+        echo "skip=${SKIP}" >> $GITHUB_OUTPUT
+        echo "version=${VERSION}" >> $GITHUB_OUTPUT
+
+        echo "Folder: ${FOLDER}"
+        echo "Release-date: ${RELEASE_DATE}"
+        echo "Skip: ${SKIP}"
+        echo "Version: ${VERSION}"

--- a/.github/workflows/rw-cdn-upload.yml
+++ b/.github/workflows/rw-cdn-upload.yml
@@ -1,0 +1,90 @@
+name: CDN Upload
+
+# Upload the content of an artifact to the CDN.
+
+on:
+  workflow_call:
+    inputs:
+      artifact-name:
+        description: The name of the artifact to download.
+        required: true
+        type: string
+      folder:
+        description: The folder to upload the artifact to.
+        required: true
+        type: string
+      version:
+        description: The version of the artifact to upload.
+        required: true
+        type: string
+    secrets:
+      CDN_SIGNING_KEY:
+        description: The signing key for the CDN.
+        required: true
+      DEPLOYMENT_APP_ID:
+        description: The ID of the GitHub App used to trigger deployments.
+        required: true
+      DEPLOYMENT_APP_PRIVATE_KEY:
+        description: The private key of the GitHub App used to trigger deployments.
+        required: true
+
+jobs:
+  cdn_upload:
+    runs-on: ubuntu-latest
+    name: CDN upload
+
+    steps:
+    - name: Download artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: ${{ inputs.artifact-name }}
+        path: artifact
+
+    - name: Install mimetype
+      shell: bash
+      run: |
+        sudo apt update
+        sudo apt install -y libfile-mimeinfo-perl --no-install-recommends
+
+    - name: Publish
+      env:
+        CDN_SIGNING_KEY: ${{ secrets.CDN_SIGNING_KEY }}
+      shell: bash
+      run: |
+        echo "${CDN_SIGNING_KEY}" > cdn_signing_key.pem
+
+        cd artifact
+
+        for i in $(ls); do
+          echo "Uploading ${i} ..."
+
+          FILENAME="${{ inputs.folder }}/${{ inputs.version }}/${i}"
+          SIGNATURE=$(echo -n "${FILENAME}" | openssl dgst -sha256 -sign ../cdn_signing_key.pem | base64 -w0)
+          CONTENT_TYPE=$(mimetype -b ${i})
+
+          curl \
+            -s \
+            --fail \
+            -X PUT \
+            -T ${i} \
+            -H "Content-Type: ${CONTENT_TYPE}" \
+            -H "X-Signature: ${SIGNATURE}" \
+            -H "User-Agent: cdn-upload/1.0" \
+            https://cdn-preview.openttd.org/${FILENAME}
+        done
+
+    - name: Generate access token
+      id: generate_token
+      uses: tibdex/github-app-token@v1
+      with:
+        app_id: ${{ secrets.DEPLOYMENT_APP_ID }}
+        private_key: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
+        repository: OpenTTD/workflows
+
+    - name: Trigger 'update CDN'
+      uses: peter-evans/repository-dispatch@v1
+      with:
+        token: ${{ steps.generate_token.outputs.token }}
+        repository: OpenTTD/workflows
+        event-type: update-cdn
+        client-payload: '{"version": "${{ inputs.version }}", "folder": "${{ inputs.folder }}"}'

--- a/.github/workflows/rw-entry-release-baseset.yml
+++ b/.github/workflows/rw-entry-release-baseset.yml
@@ -1,0 +1,78 @@
+name: Release (Baseset)
+
+# A generic reusing workflow that releases a OpenTTD baseset project (OpenGFX, OpenSFX, or OpenMSX).
+
+on:
+  workflow_call:
+    inputs:
+      apt-packages:
+        description: A list of apt packages to install.
+        required: false
+        type: string
+      name:
+        description: The name of the project.
+        required: true
+        type: string
+      pip-packages:
+        description: A list of pip packages to install.
+        required: false
+        type: string
+      problem-matcher:
+        description: A problem matcher to use.
+        default: ""
+        required: false
+        type: string
+    secrets:
+      CDN_SIGNING_KEY:
+        description: The signing key for the CDN.
+        required: true
+      DEPLOYMENT_APP_ID:
+        description: The ID of the GitHub App used to trigger deployments.
+        required: true
+      DEPLOYMENT_APP_PRIVATE_KEY:
+        description: The private key of the GitHub App used to trigger deployments.
+        required: true
+
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+jobs:
+  metadata:
+    name: Metadata
+    uses: ./.github/workflows/rw-baseset-metadata.yml
+    with:
+      name: ${{ inputs.name }}
+
+  build:
+    if: ${{ needs.metadata.outputs.skip == 'false' }}
+    needs:
+    - metadata
+
+    name: Build
+    uses: ./.github/workflows/rw-baseset-build.yml
+    with:
+      apt-packages: ${{ inputs.apt-packages }}
+      name: ${{ inputs.name }}
+      pip-packages: ${{ inputs.pip-packages }}
+      problem-matcher: ${{ inputs.problem-matcher }}
+      publish: true
+      release-date: ${{ needs.metadata.outputs.release-date }}
+      version: ${{ needs.metadata.outputs.version }}
+
+  publish:
+    if: ${{ needs.metadata.outputs.skip == 'false' }}
+    needs:
+    - build
+    - metadata
+
+    name: Publish
+    uses: ./.github/workflows/rw-cdn-upload.yml
+    secrets:
+      CDN_SIGNING_KEY: ${{ secrets.CDN_SIGNING_KEY }}
+      DEPLOYMENT_APP_ID: ${{ secrets.DEPLOYMENT_APP_ID }}
+      DEPLOYMENT_APP_PRIVATE_KEY: ${{ secrets.DEPLOYMENT_APP_PRIVATE_KEY }}
+    with:
+      artifact-name: bundles
+      folder: ${{ needs.metadata.outputs.folder }}
+      version: ${{ needs.metadata.outputs.version }}

--- a/.github/workflows/rw-entry-testing-baseset.yml
+++ b/.github/workflows/rw-entry-testing-baseset.yml
@@ -1,0 +1,48 @@
+name: Testing (Baseset)
+
+# A generic reusing workflow that tests a OpenTTD baseset project (OpenGFX, OpenSFX, or OpenMSX).
+
+on:
+  workflow_call:
+    inputs:
+      apt-packages:
+        description: A list of apt packages to install.
+        required: false
+        type: string
+      name:
+        description: The name of the project.
+        required: true
+        type: string
+      pip-packages:
+        description: A list of pip packages to install.
+        required: false
+        type: string
+      problem-matcher:
+        description: A problem matcher to use.
+        default: ""
+        required: false
+        type: string
+
+concurrency:
+  group: testing-${{ github.ref }}
+  cancel-in-progress: ${{ github.ref != 'refs/heads/main' && github.ref != 'refs/heads/master' }}
+
+jobs:
+  build:
+    name: Build
+    uses: ./.github/workflows/rw-baseset-build.yml
+    with:
+      apt-packages: ${{ inputs.apt-packages }}
+      name: ${{ inputs.name }}
+      pip-packages: ${{ inputs.pip-packages }}
+      problem-matcher: ${{ inputs.problem-matcher }}
+      publish: false
+      release-date: ""
+      version: dev
+
+  annotation_check:
+    name: Annotation Check
+    needs:
+    - build
+
+    uses: ./.github/workflows/rw-annotation-check.yml

--- a/README.md
+++ b/README.md
@@ -19,9 +19,14 @@ job:
 ```
 
 - [Annotation Check](.github/workflows/rw-annotation-check.yml): Checks if any of the earlier jobs have any annotation.
+- [Baseset - Build](.github/workflows/rw-baseset-build.yml): Build an OpenTTD baseset repository.
+- [Baseset - Metadata](.github/workflows/rw-baseset-build.yml): Detects metadata for an OpenTTD baseset repository.
+- [CDN - upload](.github/workflows/rw-cdn-upload.yml): Upload the content of an artifact to the CDN.
 - [Docker - Build](.github/workflows/rw-docker-build.yml): Build a new Docker container, multi-arch, and push to GitHub Container Registry.
 - [Entry - Preview - Docker/Nomad](.github/workflows/rw-entry-preview-docker-nomad.yml): Entrypoint for previewing projects using Docker and Nomad
+- [Entry - Release - Baseset](.github/workflows/rw-entry-release-baseset.yml): Entrypoint for releasing baseset projects (OpenGFX, OpenSFX, OpenMSX)
 - [Entry - Release - Docker/Nomad](.github/workflows/rw-entry-release-docker-nomad.yml): Entrypoint for releasing projects using Docker and Nomad
+- [Entry - Testing - Baseset](.github/workflows/rw-entry-testing-baseset.yml): Entrypoint for testing baseset projects (OpenGFX, OpenSFX, OpenMSX)
 - [Entry - Testing - Docker/Python](.github/workflows/rw-entry-testing-docker-py.yml): Entrypoint for testing projects using Docker and Python
 - [Nomad - Deploy](.github/workflows/rw-nomad-deploy.yml): Deploy a new service no Nomad.
 - [Nomad - Reload](.github/workflows/rw-nomad-reload.yml): Triggers the reload triggers of a service on Nomad.


### PR DESCRIPTION
There are three projects (OpenGFX / OpenSFX / OpenMSX) using nearly the same workflow. So they are now moved here, making it easier to maintain them.

Additional, uploading to the CDN is done in those three + OpenTTD. Condense them here too, and switch them over to the new CDN (Cloudflare R2).