### PR TITLE
Fix: cdn-upload script couldn't handle uploading subfolders

### DIFF
--- a/.github/workflows/rw-cdn-upload.yml
+++ b/.github/workflows/rw-cdn-upload.yml
@@ -55,7 +55,7 @@ jobs:
 
         cd artifact
 
-        for i in $(ls); do
+        for i in $(find -type f | cut -b 3-); do
           echo "Uploading ${i} ..."
 
           FILENAME="${{ inputs.folder }}/${{ inputs.version }}/${i}"


### PR DESCRIPTION
But instead, it uploaded a file as type "inode directory". Not actually useful.