### PR TITLE
Codechange: Use curl --fail-with-body to get additional diagnostics on failure

### DIFF
--- a/.github/workflows/rw-cdn-upload.yml
+++ b/.github/workflows/rw-cdn-upload.yml
@@ -64,13 +64,14 @@ jobs:
 
           curl \
             -s \
-            --fail \
+            --fail-with-body \
             -X PUT \
             -T ${i} \
             -H "Content-Type: ${CONTENT_TYPE}" \
             -H "X-Signature: ${SIGNATURE}" \
             -H "User-Agent: cdn-upload/1.0" \
             https://cdn.openttd.org/${FILENAME}
+          echo
         done
 
     - name: Generate access token


### PR DESCRIPTION
Oops, not in fork. Silly Github.

Also a newline.