### PR TITLE
Print annotations in annotations check and ignore ubuntu-latest warnings

### DIFF
--- a/annotation-check/src/main.ts
+++ b/annotation-check/src/main.ts
@@ -45,9 +45,13 @@ async function run(): Promise<void> {
 
       for (const annotation of annotations.data) {
         core.info(`${annotation.path}:${annotation.start_line} - ${annotation.message}`)
+        if (annotation.annotation_level === 'warning' && annotation.path === '.github') {
+          // Ignore warning annotations to do with the CI. Likely *-latest upgrade notices
+        } else {
+          count += 1
+        }
       }
     }
-    count += check_run.output.annotations_count
   }
 
   if (count === 0) {

--- a/annotation-check/src/main.ts
+++ b/annotation-check/src/main.ts
@@ -36,6 +36,17 @@ async function run(): Promise<void> {
     if (check_run.output.title) {
       core.info(`- ${check_run.output.title}: ${check_run.output.summary}`)
     }
+    if (check_run.output.annotations_count > 0) {
+      const annotations = await octokit.rest.checks.listAnnotations({
+        owner,
+        repo,
+        check_run_id: check_run.id
+      })
+
+      for (const annotation of annotations.data) {
+        core.info(`${annotation.path}:${annotation.start_line} - ${annotation.message}`)
+      }
+    }
     count += check_run.output.annotations_count
   }
 


### PR DESCRIPTION
CI is currently failing due to the annotation:
```
"ubuntu-latest pipelines will use ubuntu-24.04 soon. For more details, see https://github.com/actions/runner-images/issues/10636"
```

Apart from being irritating, this was very difficult to discover as ~I had to delve into the API results to get any output~ we all missed the error that's printed in several places. This has been an issue in the past too - discovering where a single warning is coming from in the sea of CI results can be difficult, and clicking the "Check annotations" job that has the suspicious red cross gives nothing useful except "1 annotation" or whatever.

So to start with, I've added a lookup of the annotations (if there are any) and that will be printed to the job output.

Then I added a condition to ignore annotations that start with "ubuntu-latest". Probably a bit hacky. I went with this rather than the more explicit method of writing the annotation out in full as it seems likely that they'll use this format again in future. Any other ideas, I'm all ears.

Completely untested, I've just been looking at the API documentation. No idea how to test it beyond running the CI.