### PR TITLE
Fix: Always run annotation check for PRs

### DIFF
--- a/.github/workflows/rw-entry-testing-baseset.yml
+++ b/.github/workflows/rw-entry-testing-baseset.yml
@@ -45,4 +45,10 @@ jobs:
     needs:
     - build
 
-    uses: ./.github/workflows/rw-annotation-check.yml
+    if: always() && github.event_name == 'pull_request'
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Check annotations
+      uses: OpenTTD/actions/annotation-check@v5

--- a/.github/workflows/rw-entry-testing-docker-py.yml
+++ b/.github/workflows/rw-entry-testing-docker-py.yml
@@ -59,4 +59,10 @@ jobs:
     - black
     # not codeql, as that reports its own status
 
-    uses: ./.github/workflows/rw-annotation-check.yml
+    if: always() && github.event_name == 'pull_request'
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check annotations
+        uses: OpenTTD/actions/annotation-check@v5


### PR DESCRIPTION
Annotation check is skipped if any of the needed tasks fails.
![image](https://github.com/user-attachments/assets/7893cd37-75df-4635-9818-f11329b02139)

And the required status is waiting for report. 
![image](https://github.com/user-attachments/assets/3ff833af-a273-427f-844a-3314c6c73580)

Always run the check for PRs.