### PR TITLE
Feature: use arm64 runners for arm64 builds

### DIFF
--- a/.github/workflows/rw-docker-build.yml
+++ b/.github/workflows/rw-docker-build.yml
@@ -33,10 +33,12 @@ jobs:
           include:
           - platform: linux/amd64
             name: linux-amd64
+            runner: ubuntu-latest
           - platform: linux/arm64
             name: linux-arm64
+            runner: ubuntu-24.04-arm
 
-    runs-on: ubuntu-latest
+    runs-on: ${{ matrix.runner }}
     name: Build (${{ matrix.platform }})
 
     steps:
@@ -66,9 +68,6 @@ jobs:
           type=semver,pattern={{version}}
           type=semver,pattern={{major}}.{{minor}}
           type=semver,pattern={{major}}
-
-    - name: Setup QEMU
-      uses: docker/setup-qemu-action@v3
 
     - name: Setup Buildx
       uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
GitHub published:
https://github.blog/changelog/2025-01-16-linux-arm64-hosted-runners-now-available-for-free-in-public-repositories-public-preview/

We respond with this PR. Makes building arm containers a lot faster. Like: a lot a lot. A test of the run can be observed here:
https://github.com/OpenTTD/bananas-api/actions/runs/12817132520/job/35740185119

Note: currently the arm runner shows a lot of "Unexpected error attempting to determine if executable file exists". This is a error generated by https://github.com/actions/toolkit/blob/main/packages/io/src/io-util.ts#L84 , but otherwise has no impact on the runtime. I am sure one day GitHub will get to fixing that issue, what-ever it is that is causing it. Either way: not our problem, and isn't a problem for us.