### PR TITLE
Codechange: no longer create and upload a source tarball for basesets

### DIFF
--- a/.github/workflows/rw-baseset-build.yml
+++ b/.github/workflows/rw-baseset-build.yml
@@ -77,7 +77,7 @@ jobs:
       shell: bash
       run: |
         make maintainer-clean
-        make bundle_zip bundle_xsrc
+        make bundle_zip
 
     - name: Move bundles
       if: ${{ inputs.publish }}
@@ -85,7 +85,6 @@ jobs:
       run: |
         mkdir bundles
 
-        mv ${{ inputs.name }}-${{ inputs.version }}-source.tar.xz bundles/
         mv ${{ inputs.name }}-${{ inputs.version }}-all.zip bundles/
 
     - name: Create checksums


### PR DESCRIPTION
Especially with OpenGFX2, they are huge (and cost us money to store). And the added value is low, as there is the GitHub repository. The chances of that getting lost in this day and age is very low, as there are many local copies around.