### PR TITLE
Fix: Also ignore github notices in annotation-check

### DIFF
--- a/annotation-check/dist/index.js
+++ b/annotation-check/dist/index.js
@@ -29992,8 +29992,9 @@ function run() {
             });
             for (const annotation of annotations.data) {
                 let message = `${annotation.path}:${annotation.start_line} - ${annotation.message}`;
-                if (annotation.annotation_level === 'warning' && annotation.path === '.github') {
-                    // Ignore warning annotations to do with the CI. Likely *-latest upgrade notices
+                if (annotation.path === '.github' &&
+                    (annotation.annotation_level === 'warning' || annotation.annotation_level === 'notice')) {
+                    // Ignore warning/notice annotations to do with the CI. Likely *-latest upgrade notices
                     message += ' (ignored)';
                 }
                 else {

--- a/annotation-check/src/main.ts
+++ b/annotation-check/src/main.ts
@@ -43,8 +43,11 @@ async function run(): Promise<void> {
 
     for (const annotation of annotations.data) {
       let message = `${annotation.path}:${annotation.start_line} - ${annotation.message}`
-      if (annotation.annotation_level === 'warning' && annotation.path === '.github') {
-        // Ignore warning annotations to do with the CI. Likely *-latest upgrade notices
+      if (
+        annotation.path === '.github' &&
+        (annotation.annotation_level === 'warning' || annotation.annotation_level === 'notice')
+      ) {
+        // Ignore warning/notice annotations to do with the CI. Likely *-latest upgrade notices
         message += ' (ignored)'
       } else {
         count += 1


### PR DESCRIPTION
OpenTTD CI runs are failing because:
```
Overview of jobs:
Mac OS (arm64 - Release) / CI
  .github:1 - The macos-latest label will migrate to macOS 15 beginning August 4, 2025. For more information see https://github.com/actions/runner-images/issues/12520
  .github:1 - The macos-latest label will migrate to macOS 15 beginning August 4, 2025. For more information see https://github.com/actions/runner-images/issues/12520
Mac OS (arm64 - Debug) / CI
  .github:1 - The macos-latest label will migrate to macOS 15 beginning August 4, 2025. For more information see https://github.com/actions/runner-images/issues/12520
  .github:1 - The macos-latest label will migrate to macOS 15 beginning August 4, 2025. For more information see https://github.com/actions/runner-images/issues/12520
Error: 4 annotation(s) found
```
We ignore github warnings for this reason, but this time they are using notices.

Also ignore github notices.

This PR is done on top of #94.