### PR TITLE
Fix: broken detection of forgotten 'npm run build'

### DIFF
--- a/.github/workflows/ci-annotation-check.yml
+++ b/.github/workflows/ci-annotation-check.yml
@@ -38,13 +38,12 @@ jobs:
         cd annotation-check
         npm run build
 
-        if git diff-index --quiet HEAD; then
+        if ! git diff --quiet; then
           echo "::error::Build folder is not up-to-date"
           echo "Did you forget to run 'npm run build' before committing?"
           echo "The diff looks like this:"
           echo ""
           git status
           echo ""
-          git diff
-          exit 1
+          git diff --exit-code
         fi


### PR DESCRIPTION
The detection of forgotten `npm build run` doesn't work.

First issue is the test is inverted.
The syntax is:
```
if command ; then
    # Code to run if the command's exit code is 0 (success).
else
    # Code to run if the command's exit code is non-zero (error).
fi
```
but we do the opposite.

Second issue is we use `git diff-index --quiet HEAD` to detect modified files, but in our case it will always report `annotation-check/dist/index.js`, `annotation-check/dist/main.d.ts` and `annotation-check/package-lock.json` as modified because we always regenerate them via `npm install` and `npm run build` while `git diff` will see no differences if they are actually not modified.
Output using WSL:
```
glx@LOIC:/mnt/d/developpement/GitHub/glx22/actions_wsl/annotation-check$ git diff-index HEAD
glx@LOIC:/mnt/d/developpement/GitHub/glx22/actions_wsl/annotation-check$ npm install

up to date, audited 308 packages in 761ms

127 packages are looking for funding
  run `npm fund` for details

2 low severity vulnerabilities

To address all issues, run:
  npm audit fix

Run `npm audit` for details.
glx@LOIC:/mnt/d/developpement/GitHub/glx22/actions_wsl/annotation-check$ npm run build

> build
> ncc build src/main.ts

ncc: Version 0.38.3
ncc: Compiling file index.js into CJS
ncc: Using typescript@5.8.3 (local user-provided)
   0kB  dist/main.d.ts
1106kB  dist/index.js
1106kB  [4177ms] - ncc 0.38.3
glx@LOIC:/mnt/d/developpement/GitHub/glx22/actions_wsl/annotation-check$ git diff-index HEAD
:100644 100644 a6b53838d59b93cb17ffe1bc299e4664032ac4b9 0000000000000000000000000000000000000000 M      annotation-check/dist/index.js
:100644 100644 cb0ff5c3b541f646105198ee23ac0fc3d805023e 0000000000000000000000000000000000000000 M      annotation-check/dist/main.d.ts
:100644 100644 38d5cb4f8c38fbf8f1d5b9a7c6383feb298cfdf4 0000000000000000000000000000000000000000 M      annotation-check/package-lock.json
glx@LOIC:/mnt/d/developpement/GitHub/glx22/actions_wsl/annotation-check$ git diff
glx@LOIC:/mnt/d/developpement/GitHub/glx22/actions_wsl/annotation-check$
```

So use `git diff --quiet` to detect modified files. And don't invert the test.
I also merged `git diff; exit 1` into `git diff --exit-code`.